### PR TITLE
Remove deprecated has_rdoc attribute from gemspec

### DIFF
--- a/gpx.gemspec
+++ b/gpx.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split($/)
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
-  s.has_rdoc = true
+  # s.has_rdoc = true
 
   s.homepage = "http://www.github.com/dougfales/gpx"
   s.add_dependency 'rake'


### PR DESCRIPTION
The has_rdoc attribute has been deprecated since RubyGems 1.7.0 and will be removed in RubyGems 4. It now shows deprecation warnings when building the gem. Commenting it out to clean up the gemspec.

GitHub: https://github.com/artofthetrekcom/gpx/pull/1
Trello: https://trello.com/c/SnsslLEG